### PR TITLE
add support for scientific notation

### DIFF
--- a/dynamicarray.c
+++ b/dynamicarray.c
@@ -65,7 +65,7 @@ extern void DynamicArrayAdd(DynamicArray *dynamic_array, JSONValue *element, u_i
 
 static void dynamicArrayResize(DynamicArray *dynamic_array)
 {
-    printf("resizing array!\n");
+    // printf("resizing array!\n");
     if (dynamic_array == NULL)
     {
         return;

--- a/hashmap.c
+++ b/hashmap.c
@@ -105,10 +105,6 @@ extern void HashMapInsert(HashMap *map, JSONValue *entry)
     {
         map->size++;
     }
-    // else
-    // {
-    //     printf("COLLISOIN!\n");
-    // }
 }
 
 static bool hashMapEntriesInsert(JSONValue **entries, u_int32_t index, JSONValue *entry)
@@ -119,7 +115,6 @@ static bool hashMapEntriesInsert(JSONValue **entries, u_int32_t index, JSONValue
         entries[index] = entry;
         return false;
     }
-
     JSONValue *iterator_prev = collision;
     JSONValue *iterator = collision->next;
     while (iterator != NULL)
@@ -338,7 +333,6 @@ static void hashMapResize(HashMap *map)
     {
         return;
     }
-    printf("Resizing Hash Map!\n");
 
     u_int32_t new_capacity = map->capacity * DEFAULT_MAP_RESIZE_MULTIPLE;
     u_int32_t new_size = 0;

--- a/json.c
+++ b/json.c
@@ -7,7 +7,7 @@
 #include "./util.h"
 
 static void printJSONStringValue(char *);
-static void printJSONNumberIntValue(int *value);
+static void printJSONNumberIntValue(int64_t *value);
 static void printJSONNumberDoubleValue(double *value);
 
 static void printJSONBoolValue(bool *);
@@ -167,14 +167,14 @@ static void printJSONStringValue(char *value)
     printf("\"%s\"", value);
 }
 
-static void printJSONNumberIntValue(int *value)
+static void printJSONNumberIntValue(int64_t *value)
 {
-    printf("%d", *value);
+    printf("%lld", *value);
 }
 
 static void printJSONNumberDoubleValue(double *value)
 {
-    printf("%f", *value);
+    printf("%lf", *value);
 }
 
 static void printJSONBoolValue(bool *value)

--- a/json.h
+++ b/json.h
@@ -47,7 +47,7 @@ extern void PrintJSONValue(JSONValue *);
 // ————————— JSON END —————————
 
 // ————————— HASHMAP START —————————
-#define DEFAULT_MAP_SIZE 1
+#define DEFAULT_MAP_SIZE 16
 #define DEFAULT_MAP_RESIZE_MULTIPLE 2
 
 typedef u_int32_t(HashFunction)(char *, u_int32_t);
@@ -71,7 +71,7 @@ extern void PrintHashMap(HashMap *);
 // ————————— HASHMAP END —————————
 
 // ————————— DYN ARRAY START —————————
-#define DEFAULT_DYN_ARR_SIZE 20
+#define DEFAULT_DYN_ARR_SIZE 10
 #define DEFAULT_DYN_ARR_RESIZE_MULTIPLE 2
 
 typedef struct

--- a/main.c
+++ b/main.c
@@ -11,7 +11,7 @@ int main(void)
     {
         return EXIT_FAILURE;
     }
-    // PrintJSON(json);
+    //PrintJSON(json);
     FreeJSON(json);
     return EXIT_SUCCESS;
 }

--- a/parser.c
+++ b/parser.c
@@ -274,17 +274,15 @@ static JSONValue *initQuickJSONValue(enum JSONValueType value_type, void *value)
     else if (value_type == NUMBER_DOUBLE_t)
     {
         double *new_double = malloc(sizeof(double));
-        double temp = atof((char *)value);
-        *new_double = temp;
+        *new_double = atof((char *)value);
         value_len = 1;
         json_value->value = new_double;
         free(value);
     }
     else if (value_type == NUMBER_INT_t)
     {
-        int *new_int = malloc(sizeof(int));
-        int temp = atoi((char *)value);
-        *new_int = temp;
+        int64_t *new_int = malloc(sizeof(int64_t));
+        *new_int = (int64_t)atof((char *)value);
         value_len = 1;
         json_value->value = new_int;
         free(value);

--- a/util.h
+++ b/util.h
@@ -13,6 +13,7 @@
 #define NEWLINE_CHAR '\n'
 #define CARRIAGE_CHAR '\r'
 #define DASH_MINUS_CHAR '-'
+#define PLUS_CHAR '+'
 
 #define DOT_CHAR '.'
 #define COMMA_CHAR ','


### PR DESCRIPTION
- switch from `int` to `int64_t`
- add more parsing checks for `makeNumberLiteral`